### PR TITLE
Fixes retrieval of version string from source files doc blocks (fixes #36)

### DIFF
--- a/behat.yml
+++ b/behat.yml
@@ -1,0 +1,7 @@
+default:
+  suites:
+    default:
+      contexts:
+        - WP_CLI\Tests\Context\FeatureContext
+      paths:
+        - features

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
         }
     ],
     "require": {
-        "php": ">=5.4",
+        "php": ">=5.6",
         "wp-cli/wp-cli": "^2"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -52,5 +52,10 @@
             "@phpunit",
             "@behat"
         ]
+    },
+    "config": {
+        "allow-plugins": {
+            "dealerdirect/phpcodesniffer-composer-installer": true
+        }
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "wp-cli/dist-archive-command",
     "type": "wp-cli-package",
     "description": "Create a distribution .zip or .tar.gz based on a plugin or theme's .distignore file.",
-    "homepage": "https://runcommand.io/wp/dist-archive/",
+    "homepage": "https://github.com/wp-cli/dist-archive-command/",
     "license": "MIT",
     "authors": [
         {

--- a/composer.json
+++ b/composer.json
@@ -16,8 +16,7 @@
         "wp-cli/wp-cli": "^2"
     },
     "require-dev": {
-        "behat/behat": "~2.5",
-        "wp-cli/wp-cli-tests": "^2.1",
+        "wp-cli/wp-cli-tests": "^3",
         "wp-cli/scaffold-command": "^2",
         "wp-cli/extension-command": "^2"
     },
@@ -40,6 +39,7 @@
         ]
     },
     "minimum-stability": "dev",
+    "prefer-stable": true,
     "scripts": {
         "behat": "run-behat-tests",
         "lint": "run-linter-tests",

--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
         ],
         "readme": {
             "shields": [
-                "[![CircleCI](https://circleci.com/gh/wp-cli/dist-archive-command/tree/master.svg?style=svg)](https://circleci.com/gh/wp-cli/dist-archive-command/tree/master)"
+                "[![Testing](https://github.com/wp-cli/dist-archive-command/actions/workflows/testing.yml/badge.svg)](https://github.com/wp-cli/dist-archive-command/actions/workflows/testing.yml)"
             ]
         }
     },

--- a/features/dist-archive.feature
+++ b/features/dist-archive.feature
@@ -173,25 +173,54 @@ Feature: Generate a distribution archive of a project
     And the {RUN_DIR}/some/nested/folder/hello-world.zip file should exist
 
   Scenario: Generates an archive with another name using the plugin-dirname flag
-	Given a WP install
+    Given a WP install
 
-	When I run `wp scaffold plugin hello-world`
-	Then the wp-content/plugins/hello-world directory should exist
-	And the wp-content/plugins/hello-world/hello-world.php file should exist
-	And the wp-content/plugins/hello-world/.travis.yml file should exist
-	And the wp-content/plugins/hello-world/bin directory should exist
+    When I run `wp scaffold plugin hello-world`
+    Then the wp-content/plugins/hello-world directory should exist
+    And the wp-content/plugins/hello-world/hello-world.php file should exist
+    And the wp-content/plugins/hello-world/.travis.yml file should exist
+    And the wp-content/plugins/hello-world/bin directory should exist
 
-	When I run `wp dist-archive wp-content/plugins/hello-world --plugin-dirname=foobar-world`
-	Then STDOUT should be:
+    When I run `wp dist-archive wp-content/plugins/hello-world --plugin-dirname=foobar-world`
+    Then STDOUT should be:
+        """
+        Success: Created foobar-world.0.1.0.zip
+        """
+    And STDERR should be empty
+    And the wp-content/plugins/foobar-world.0.1.0.zip file should exist
+
+    When I run `wp plugin delete hello-world`
+    Then the wp-content/plugins/hello-world directory should not exist
+
+    When I run `wp plugin install wp-content/plugins/foobar-world.0.1.0.zip`
+    Then the wp-content/plugins/foobar-world directory should exist
+    And the wp-content/plugins/foobar-world/hello-world.php file should exist
+
+  Scenario: Finds the version tag even if ill-formed
+    Given a WP install
+
+    When I run `wp scaffold plugin hello-world`
+    Then the wp-content/plugins/hello-world directory should exist
+    And the wp-content/plugins/hello-world/hello-world.php file should exist
+    And the wp-content/plugins/hello-world/.travis.yml file should exist
+    And the wp-content/plugins/hello-world/bin directory should exist
+
+    When I run `sed -i wp-content/plugins/hello-world/hello-world.php -e "s/* Version:/Version/" -e "s/0.1.0/0.2.0/"`
+    Then STDERR should be empty
+
+    When I run `wp dist-archive wp-content/plugins/hello-world`
+    Then STDOUT should be:
       """
-      Success: Created foobar-world.0.1.0.zip
+      Success: Created hello-world.0.2.0.zip
       """
-	And STDERR should be empty
-	And the wp-content/plugins/foobar-world.0.1.0.zip file should exist
+    And STDERR should be empty
+    And the wp-content/plugins/hello-world.0.1.0.zip file should exist
 
-	When I run `wp plugin delete hello-world`
-	Then the wp-content/plugins/hello-world directory should not exist
+    When I run `wp plugin delete hello-world`
+    Then the wp-content/plugins/hello-world directory should not exist
 
-	When I run `wp plugin install wp-content/plugins/foobar-world.0.1.0.zip`
-	Then the wp-content/plugins/foobar-world directory should exist
-	And the wp-content/plugins/foobar-world/hello-world.php file should exist
+    When I run `wp plugin install wp-content/plugins/hello-world.0.1.0.zip`
+    Then the wp-content/plugins/hello-world directory should exist
+    And the wp-content/plugins/hello-world/hello-world.php file should exist
+    And the wp-content/plugins/hello-world/.travis.yml file should not exist
+    And the wp-content/plugins/hello-world/bin directory should not exist

--- a/features/dist-archive.feature
+++ b/features/dist-archive.feature
@@ -214,12 +214,12 @@ Feature: Generate a distribution archive of a project
       Success: Created hello-world.0.2.0.zip
       """
     And STDERR should be empty
-    And the wp-content/plugins/hello-world.0.1.0.zip file should exist
+    And the wp-content/plugins/hello-world.0.2.0.zip file should exist
 
     When I run `wp plugin delete hello-world`
     Then the wp-content/plugins/hello-world directory should not exist
 
-    When I run `wp plugin install wp-content/plugins/hello-world.0.1.0.zip`
+    When I run `wp plugin install wp-content/plugins/hello-world.0.2.0.zip`
     Then the wp-content/plugins/hello-world directory should exist
     And the wp-content/plugins/hello-world/hello-world.php file should exist
     And the wp-content/plugins/hello-world/.travis.yml file should not exist

--- a/features/dist-archive.feature
+++ b/features/dist-archive.feature
@@ -205,7 +205,7 @@ Feature: Generate a distribution archive of a project
     And the wp-content/plugins/hello-world/.travis.yml file should exist
     And the wp-content/plugins/hello-world/bin directory should exist
 
-    When I run `sed -i wp-content/plugins/hello-world/hello-world.php -e "s/* Version:/Version/" -e "s/0.1.0/0.2.0/"`
+    When I run `sed -i wp-content/plugins/hello-world/hello-world.php -e "s/* Version/Version/" -e "s/0.1.0/0.2.0/"`
     Then STDERR should be empty
 
     When I run `wp dist-archive wp-content/plugins/hello-world`

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -38,7 +38,7 @@
 
  	<!-- For help understanding the `testVersion` configuration setting:
 		 https://github.com/PHPCompatibility/PHPCompatibility#sniffing-your-code-for-compatibility-with-specific-php-versions -->
-	<config name="testVersion" value="5.4-"/>
+	<config name="testVersion" value="5.6-"/>
 
  	<!-- Verify that everything in the global namespace is either namespaced or prefixed.
 		 See: https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/wiki/Customizable-sniff-properties#naming-conventions-prefix-everything-in-the-global-namespace -->

--- a/src/Dist_Archive_Command.php
+++ b/src/Dist_Archive_Command.php
@@ -96,7 +96,8 @@ class Dist_Archive_Command {
 		foreach ( glob( $path . '/*.php' ) as $php_file ) {
 			$contents = file_get_contents( $php_file, false, null, 0, 5000 );
 			$version = $this->get_version_in_code($contents);
-			if( null !== $version ) {
+			if( ! empty( $version ) ) {
+				$version = '.' . trim($version);
 				break;
 			}
 		}

--- a/src/Dist_Archive_Command.php
+++ b/src/Dist_Archive_Command.php
@@ -123,7 +123,10 @@ class Dist_Archive_Command {
 			$tmp_dir        = sys_get_temp_dir() . DIRECTORY_SEPARATOR . $plugin_dirname . $version . '.' . time();
 			$new_path       = $tmp_dir . DIRECTORY_SEPARATOR . $plugin_dirname;
 			mkdir( $new_path, 0777, true );
-			$iterator = new \RecursiveIteratorIterator( new \RecursiveDirectoryIterator( $path, \RecursiveDirectoryIterator::SKIP_DOTS ), \RecursiveIteratorIterator::SELF_FIRST );
+			$iterator = new RecursiveIteratorIterator(
+				new RecursiveDirectoryIterator( $path, RecursiveDirectoryIterator::SKIP_DOTS ),
+				RecursiveIteratorIterator::SELF_FIRST
+			);
 			foreach ( $iterator as $item ) {
 				if ( $item->isDir() ) {
 					mkdir( $new_path . DIRECTORY_SEPARATOR . $iterator->getSubPathName() );
@@ -190,7 +193,7 @@ class Dist_Archive_Command {
 			$filename = pathinfo( $archive_file, PATHINFO_BASENAME );
 			WP_CLI::success( "Created {$filename}" );
 		} else {
-			$error = $ret->stderr ? $ret->stderr : $ret->stdout;
+			$error = $ret->stderr ?: $ret->stdout;
 			WP_CLI::error( $error );
 		}
 	}
@@ -216,7 +219,7 @@ class Dist_Archive_Command {
 	 * @param string $code_str the source code string to look into
 	 * @return null|string the version string
 	 */
-	private static function get_version_in_code( $code_str ) {
+	private function get_version_in_code( $code_str ) {
 		$tokens = array_values(
 			array_filter(
 				token_get_all( $code_str ),
@@ -227,7 +230,7 @@ class Dist_Archive_Command {
 		);
 		foreach ( $tokens as $token ) {
 			if ( T_DOC_COMMENT === $token[0] ) {
-				$version = self::get_version_in_docblock( $token[1] );
+				$version = $this->get_version_in_docblock( $token[1] );
 				if ( null !== $version ) {
 					return $version;
 				}
@@ -242,8 +245,8 @@ class Dist_Archive_Command {
 	 * @param string $docblock
 	 * @return null|string The content of the version tag
 	*/
-	private static function get_version_in_docblock( $docblock ) {
-		$docblocktags = self::parse_doc_block( $docblock );
+	private function get_version_in_docblock( $docblock ) {
+		$docblocktags = $this->parse_doc_block( $docblock );
 		if ( isset( $docblocktags['version'] ) ) {
 			return $docblocktags['version'];
 		}
@@ -261,7 +264,7 @@ class Dist_Archive_Command {
 	 * @param string $docblock
 	 * @return array
 	*/
-	private static function parse_doc_block( $docblock ) {
+	private function parse_doc_block( $docblock ) {
 		$tag_documentor = '{@([a-zA-Z0-9-_\\\]+)\s*?(.*)?}';
 		$tag_property   = '{\s*\*?\s*(.*?):(.*)}';
 		$lines          = explode( PHP_EOL, $docblock );

--- a/src/Dist_Archive_Command.php
+++ b/src/Dist_Archive_Command.php
@@ -95,9 +95,9 @@ class Dist_Archive_Command {
 		$version = '';
 		foreach ( glob( $path . '/*.php' ) as $php_file ) {
 			$contents = file_get_contents( $php_file, false, null, 0, 5000 );
-			$version = $this->get_version_in_code($contents);
-			if( ! empty( $version ) ) {
-				$version = '.' . trim($version);
+			$version  = $this->get_version_in_code( $contents );
+			if ( ! empty( $version ) ) {
+				$version = '.' . trim( $version );
 				break;
 			}
 		}
@@ -216,20 +216,18 @@ class Dist_Archive_Command {
 	 * @param string $code_str the source code string to look into
 	 * @return null|string the version string
 	 */
-
-	private static function get_version_in_code($code_str)
-	{
+	private static function get_version_in_code( $code_str ) {
 		$tokens = array_values(
 			array_filter(
-				token_get_all($code_str),
-				function ($token) {
-					return !is_array($token) || $token[0] !== T_WHITESPACE;
+				token_get_all( $code_str ),
+				function ( $token ) {
+					return ! is_array( $token ) || T_WHITESPACE !== $token[0];
 				}
 			)
 		);
 		foreach ( $tokens as $token ) {
-			if ( $token[0] == T_DOC_COMMENT	) {
-				$version = self::get_version_in_docblock($token[1]);
+			if ( T_DOC_COMMENT === $token[0] ) {
+				$version = self::get_version_in_docblock( $token[1] );
 				if ( null !== $version ) {
 					return $version;
 				}
@@ -244,10 +242,9 @@ class Dist_Archive_Command {
 	 * @param string $docblock
 	 * @return null|string The content of the version tag
 	*/
-	private static function get_version_in_docblock($docblock)
-	{
-		$docblocktags = self::parse_doc_block($docblock);
-		if ( isset($docblocktags['version'] ) ) {
+	private static function get_version_in_docblock( $docblock ) {
+		$docblocktags = self::parse_doc_block( $docblock );
+		if ( isset( $docblocktags['version'] ) ) {
 			return $docblocktags['version'];
 		}
 		return null;
@@ -264,23 +261,24 @@ class Dist_Archive_Command {
 	 * @param string $docblock
 	 * @return array
 	*/
-	private static function parse_doc_block($docblock): array
-	{
+	private static function parse_doc_block( $docblock ) {
 		$tag_documentor = '{@([a-zA-Z0-9-_\\\]+)\s*?(.*)?}';
-		$tag_property = '{\s*\*?\s*(.*?)\:(.*)}';
-		$lines = explode(PHP_EOL, $docblock);
-		$tags = [];
-		$prose = [];
-		foreach ($lines as $line) {
-			if (0 === preg_match($tag_documentor, $line, $matches)) {
-				if (0 === preg_match($tag_property, $line, $matches)) {
+		$tag_property   = '{\s*\*?\s*(.*?):(.*)}';
+		$lines          = explode( PHP_EOL, $docblock );
+		$tags           = [];
+
+		foreach ( $lines as $line ) {
+			if ( 0 === preg_match( $tag_documentor, $line, $matches ) ) {
+				if ( 0 === preg_match( $tag_property, $line, $matches ) ) {
 					continue;
 				}
 			}
-			$tagName = strtolower($matches[1]);
-			$metadata = trim($matches[2] ?? '');
-			$tags[$tagName] = $metadata;
+
+			$tag_name = strtolower( $matches[1] );
+			$metadata = trim( isset( $matches[2] ) ? $matches[2] : '' );
+
+			$tags[ $tag_name ] = $metadata;
 		}
 		return $tags;
-    }
+	}
 }

--- a/src/Dist_Archive_Command.php
+++ b/src/Dist_Archive_Command.php
@@ -219,15 +219,15 @@ class Dist_Archive_Command {
 
 	private static function get_version_in_code($code_str)
 	{
-        $tokens = array_values(
-            array_filter(
-                token_get_all($code_str),
-                function ($token) {
-                    return !is_array($token) || $token[0] !== T_WHITESPACE;
-                }
-            )
-        );
-        foreach ( $tokens as $token ) {
+		$tokens = array_values(
+			array_filter(
+				token_get_all($code_str),
+				function ($token) {
+					return !is_array($token) || $token[0] !== T_WHITESPACE;
+				}
+			)
+		);
+		foreach ( $tokens as $token ) {
 			if ( $token[0] == T_DOC_COMMENT	) {
 				$version = self::get_version_in_docblock($token[1]);
 				if ( null !== $version ) {
@@ -268,19 +268,19 @@ class Dist_Archive_Command {
     {
 		$tag_documentor = '{@([a-zA-Z0-9-_\\\]+)\s*?(.*)?}';
 		$tag_property = '{\s*\*?\s*(.*?)\:(.*)}';
-        $lines = explode(PHP_EOL, $docblock);
-        $tags = [];
-        $prose = [];
-        foreach ($lines as $line) {
-            if (0 === preg_match($tag_documentor, $line, $matches)) {
+		$lines = explode(PHP_EOL, $docblock);
+		$tags = [];
+		$prose = [];
+		foreach ($lines as $line) {
+			if (0 === preg_match($tag_documentor, $line, $matches)) {
 				if (0 === preg_match($tag_property, $line, $matches)) {
 					continue;
 				}
 			}
-            $tagName = strtolower($matches[1]);
-            $metadata = trim($matches[2] ?? '');
-            $tags[$tagName] = $metadata;
-        }
-        return $tags;
+			$tagName = strtolower($matches[1]);
+			$metadata = trim($matches[2] ?? '');
+			$tags[$tagName] = $metadata;
+		}
+		return $tags;
     }
 }

--- a/src/Dist_Archive_Command.php
+++ b/src/Dist_Archive_Command.php
@@ -264,8 +264,8 @@ class Dist_Archive_Command {
 	 * @param string $docblock
 	 * @return array
 	*/
-    private static function parse_doc_block($docblock): array
-    {
+	private static function parse_doc_block($docblock): array
+	{
 		$tag_documentor = '{@([a-zA-Z0-9-_\\\]+)\s*?(.*)?}';
 		$tag_property = '{\s*\*?\s*(.*?)\:(.*)}';
 		$lines = explode(PHP_EOL, $docblock);


### PR DESCRIPTION
 In the issue there is a suggestion to refactor code from the `i18n` command. However, the code in the `i18n` command can't be used as is because it only handles functions, and the `plugin.php` header doesn't have to have a function on it.

I have replaced the former `preg_match` on the contents of all the php files in the plugin into a more sophisticated way of extracting the version tag:

* Use php's `token_get_all` to parse the php file
* For each `doc_block`, parse it to get all the tags
* return the `version` tag.

It's worth noting that the tags might be specified as @version or Version: and that a leading * might be in the line.
