### PR TITLE
Implement CS checking based on the `WP_CLI_CS` ruleset

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,6 @@ composer.lock
 node_modules/
 vendor/
 *.log
+phpunit.xml
+phpcs.xml
+.phpcs.xml

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
     },
     "require-dev": {
         "behat/behat": "~2.5",
-        "wp-cli/wp-cli-tests": "^2",
+        "wp-cli/wp-cli-tests": "^2.1",
         "wp-cli/scaffold-command": "^2",
         "wp-cli/extension-command": "^2"
     },

--- a/dist-archive-command.php
+++ b/dist-archive-command.php
@@ -4,9 +4,9 @@ if ( ! class_exists( 'WP_CLI' ) ) {
 	return;
 }
 
-$autoload = dirname( __FILE__ ) . '/vendor/autoload.php';
-if ( file_exists( $autoload ) ) {
-	require_once $autoload;
+$wpcli_dist_archive_autoloader = dirname( __FILE__ ) . '/vendor/autoload.php';
+if ( file_exists( $wpcli_dist_archive_autoloader ) ) {
+	require_once $wpcli_dist_archive_autoloader;
 }
 
 WP_CLI::add_command( 'dist-archive', 'Dist_Archive_Command' );

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -1,61 +1,54 @@
 <?xml version="1.0"?>
-<ruleset name="WP-CLI">
-	<description>Custom ruleset for WP-CLI</description>
+<ruleset name="WP-CLI-dist-archive">
+	<description>Custom ruleset for WP-CLI dist-archive-command</description>
 
-	<!-- For help in understanding this file: https://github.com/squizlabs/PHP_CodeSniffer/wiki/Annotated-ruleset.xml -->
-	<!-- For help in using PHPCS: https://github.com/squizlabs/PHP_CodeSniffer/wiki/Usage -->
+ 	<!--
+	#############################################################################
+	COMMAND LINE ARGUMENTS
+	For help understanding this file: https://github.com/squizlabs/PHP_CodeSniffer/wiki/Annotated-ruleset.xml
+	For help using PHPCS: https://github.com/squizlabs/PHP_CodeSniffer/wiki/Usage
+	#############################################################################
+	-->
 
-	<!-- What to scan -->
+ 	<!-- What to scan. -->
 	<file>.</file>
-	<!-- Ignoring Files and Folders:
-		https://github.com/squizlabs/PHP_CodeSniffer/wiki/Advanced-Usage#ignoring-files-and-folders -->
-	<exclude-pattern>*/.git/*</exclude-pattern>
-	<exclude-pattern>*/ci/*</exclude-pattern>
-	<exclude-pattern>*/features/*</exclude-pattern>
-	<exclude-pattern>*/packages/*</exclude-pattern>
-	<exclude-pattern>*/tests/*</exclude-pattern>
-	<exclude-pattern>*/utils/*</exclude-pattern>
-	<exclude-pattern>*/vendor/*</exclude-pattern>
 
-	<!-- How to scan -->
-	<arg value="sp"/> <!-- Show sniff and progress -->
-	<arg name="colors"/> <!-- Show results with colors -->
-	<arg name="extensions" value="php"/> <!-- Limit to PHP files -->
+ 	<!-- Show progress. -->
+	<arg value="p"/>
 
-	<!-- Rules: Check PHP version compatibility - see
-		https://github.com/PHPCompatibility/PHPCompatibilityWP -->
-	<rule ref="PHPCompatibilityWP">
-		<!-- Polyfill package is used so array_column() is available for PHP 5.4- -->
-		<exclude name="PHPCompatibility.PHP.NewFunctions.array_columnFound"/>
-		<!-- Both magic quotes directives set in wp-settings-cli.php to provide consistent starting point. -->
-		<exclude name="PHPCompatibility.PHP.DeprecatedIniDirectives.magic_quotes_runtimeDeprecatedRemoved"/>
-		<exclude name="PHPCompatibility.PHP.DeprecatedIniDirectives.magic_quotes_sybaseDeprecatedRemoved"/>
-	</rule>
+ 	<!-- Strip the filepaths down to the relevant bit. -->
+	<arg name="basepath" value="./"/>
 
-	<!-- For help in understanding this testVersion:
-		https://github.com/PHPCompatibility/PHPCompatibility#sniffing-your-code-for-compatibility-with-specific-php-versions -->
-	<config name="testVersion" value="5.3-"/>
+ 	<!-- Check up to 8 files simultaneously. -->
+	<arg name="parallel" value="8"/>
 
-	<!-- Ignore php_uname mode issue, we're conditionally providing a callback -->
-	<rule ref="PHPCompatibility.PHP.NewFunctionParameters.php_uname_modeFound">
-		<exclude-pattern>*/php/commands/src/CLI_Command.php</exclude-pattern>
-	</rule>
+ 	<!--
+	#############################################################################
+	USE THE WP_CLI_CS RULESET
+	#############################################################################
+	-->
 
-	<!-- Rules: WordPress Coding Standards - see
-		https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards -->
-	<rule ref="WordPress-Core">
-		<exclude name="Squiz.PHP.DisallowMultipleAssignments.Found" />
-		<exclude name="WordPress.NamingConventions.ValidVariableName.NotSnakeCaseMemberVar" />
-		<exclude name="WordPress.NamingConventions.ValidVariableName.MemberNotSnakeCase" />
-		<exclude name="WordPress.NamingConventions.ValidVariableName.NotSnakeCase" />
-	</rule>
+ 	<rule ref="WP_CLI_CS"/>
 
-	<!-- For help in understanding these custom sniff properties:
-		https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/wiki/Customizable-sniff-properties -->
-	<rule ref="WordPress.Files.FileName">
+ 	<!--
+	#############################################################################
+	PROJECT SPECIFIC CONFIGURATION FOR SNIFFS
+	#############################################################################
+	-->
+
+ 	<!-- For help understanding the `testVersion` configuration setting:
+		 https://github.com/PHPCompatibility/PHPCompatibility#sniffing-your-code-for-compatibility-with-specific-php-versions -->
+	<config name="testVersion" value="5.4-"/>
+
+ 	<!-- Verify that everything in the global namespace is either namespaced or prefixed.
+		 See: https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/wiki/Customizable-sniff-properties#naming-conventions-prefix-everything-in-the-global-namespace -->
+	<rule ref="WordPress.NamingConventions.PrefixAllGlobals">
 		<properties>
-			<property name="strict_class_file_names" value="false"/>
+			<property name="prefixes" type="array">
+				<element value="WP_CLI\DistArchive"/><!-- Namespaces. -->
+				<element value="wpcli_dist_archive"/><!-- Global variables and such. -->
+			</property>
 		</properties>
-		<exclude name="WordPress.Files.FileName.NotHyphenatedLowercase" />
 	</rule>
-</ruleset>
+
+ </ruleset>

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -43,6 +43,7 @@
  	<!-- Verify that everything in the global namespace is either namespaced or prefixed.
 		 See: https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/wiki/Customizable-sniff-properties#naming-conventions-prefix-everything-in-the-global-namespace -->
 	<rule ref="WordPress.NamingConventions.PrefixAllGlobals">
+	<exclude name="WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedClassFound" />
 		<properties>
 			<property name="prefixes" type="array">
 				<element value="WP_CLI\DistArchive"/><!-- Namespaces. -->

--- a/src/Dist_Archive_Command.php
+++ b/src/Dist_Archive_Command.php
@@ -145,7 +145,8 @@ class Dist_Archive_Command {
 						$ignored_file = substr( $ignored_file, 0, ( strlen( $ignored_file ) - 2 ) );
 					}
 						return "--exclude='{$ignored_file}'";
-				}, $ignored_files
+				},
+				$ignored_files
 			);
 			$excludes = implode( ' ', $excludes );
 			$cmd      = "tar {$excludes} -zcvf {$archive_file} {$archive_base}";


### PR DESCRIPTION
Add a PHPCS ruleset using the new WP_CLI_CS standard.

Fixes #38 

related https://github.com/wp-cli/wp-cli/issues/5179