### PR TITLE
Escape the archive file to allow spaces in path

### DIFF
--- a/src/Dist_Archive_Command.php
+++ b/src/Dist_Archive_Command.php
@@ -137,7 +137,7 @@ class Dist_Archive_Command {
 			if ( ! empty( $excludes ) ) {
 				$excludes = ' --exclude ' . $excludes;
 			}
-			$cmd = "zip -r {$archive_file} {$archive_base} {$excludes}";
+			$cmd = "zip -r '{$archive_file}' {$archive_base} {$excludes}";
 		} elseif ( 'targz' === $assoc_args['format'] ) {
 			$excludes = array_map(
 				function( $ignored_file ) {


### PR DESCRIPTION
Ran into this using Local by Flywheel which has a space in their main path.  This was suggested in #40, I just implemented it.