### PR TITLE
Add `--plugin-dirname=<plugin-slug>` option for archive output

### DIFF
--- a/features/dist-archive.feature
+++ b/features/dist-archive.feature
@@ -171,3 +171,27 @@ Feature: Generate a distribution archive of a project
       """
     And STDERR should be empty
     And the {RUN_DIR}/some/nested/folder/hello-world.zip file should exist
+
+  Scenario: Generates an archive with another name using the plugin-dirname flag
+	Given a WP install
+
+	When I run `wp scaffold plugin hello-world`
+	Then the wp-content/plugins/hello-world directory should exist
+	And the wp-content/plugins/hello-world/hello-world.php file should exist
+	And the wp-content/plugins/hello-world/.travis.yml file should exist
+	And the wp-content/plugins/hello-world/bin directory should exist
+
+	When I run `wp dist-archive wp-content/plugins/hello-world --plugin-dirname=foobar-world`
+	Then STDOUT should be:
+      """
+      Success: Created foobar-world.0.1.0.zip
+      """
+	And STDERR should be empty
+	And the wp-content/plugins/foobar-world.0.1.0.zip file should exist
+
+	When I run `wp plugin delete hello-world`
+	Then the wp-content/plugins/hello-world directory should not exist
+
+	When I run `wp plugin install wp-content/plugins/foobar-world.0.1.0.zip`
+	Then the wp-content/plugins/foobar-world directory should exist
+	And the wp-content/plugins/foobar-world/hello-world.php file should exist

--- a/src/Dist_Archive_Command.php
+++ b/src/Dist_Archive_Command.php
@@ -122,8 +122,8 @@ class Dist_Archive_Command {
 			$tmp_dir        = sys_get_temp_dir() . DIRECTORY_SEPARATOR . $plugin_dirname . $version . '.' . time();
 			$new_path       = $tmp_dir . DIRECTORY_SEPARATOR . $plugin_dirname;
 			mkdir( $new_path, 0777, true );
-			// phpcs:ignore Squiz.PHP.DisallowMultipleAssignments.Found
-			foreach ( $iterator = new \RecursiveIteratorIterator( new \RecursiveDirectoryIterator( $path, \RecursiveDirectoryIterator::SKIP_DOTS ), \RecursiveIteratorIterator::SELF_FIRST ) as $item ) {
+			$iterator = new \RecursiveIteratorIterator( new \RecursiveDirectoryIterator( $path, \RecursiveDirectoryIterator::SKIP_DOTS ), \RecursiveIteratorIterator::SELF_FIRST );
+			foreach ( $iterator as $item ) {
 				if ( $item->isDir() ) {
 					mkdir( $new_path . DIRECTORY_SEPARATOR . $iterator->getSubPathName() );
 				} else {


### PR DESCRIPTION
If the desired output directory is different to the source directory name, copy the files to the system temp directory with the required name, then zip.

I've been using this for a couple of weeks now and it seems robust.

Fixes #42