### PR TITLE
Allow operation without .distignore file

### DIFF
--- a/features/dist-archive.feature
+++ b/features/dist-archive.feature
@@ -224,3 +224,21 @@ Feature: Generate a distribution archive of a project
     And the wp-content/plugins/hello-world/hello-world.php file should exist
     And the wp-content/plugins/hello-world/.travis.yml file should not exist
     And the wp-content/plugins/hello-world/bin directory should not exist
+
+  Scenario: Warns but continues when no distignore file is present
+	Given an empty directory
+	And a test-plugin.php file:
+      """
+      <?php
+	  /**
+	   * Plugin Name:       Test Plugin
+	   * Version:           1.0.0
+	   */
+      """
+
+	When I try `wp dist-archive . test-plugin.zip`
+	Then STDERR should contain:
+      """
+	  No .distignore file found. All files in directory included in archive.
+      """
+	And the test-plugin.zip file should exist

--- a/src/Dist_Archive_Command.php
+++ b/src/Dist_Archive_Command.php
@@ -72,13 +72,15 @@ class Dist_Archive_Command {
 		}
 
 		$dist_ignore_path = $path . '/.distignore';
-		if ( ! file_exists( $dist_ignore_path ) ) {
-			WP_CLI::error( 'No .distignore file found.' );
+		if ( file_exists( $dist_ignore_path ) ) {
+			$maybe_ignored_files = explode( PHP_EOL, file_get_contents( $dist_ignore_path ) );
+		} else {
+			WP_CLI::warning( 'No .distignore file found. All files in directory included in archive.' );
+			$maybe_ignored_files = array();
 		}
 
-		$maybe_ignored_files = explode( PHP_EOL, file_get_contents( $dist_ignore_path ) );
-		$ignored_files       = array();
-		$archive_base        = basename( $path );
+		$ignored_files = array();
+		$archive_base  = basename( $path );
 		foreach ( $maybe_ignored_files as $file ) {
 			$file = trim( $file );
 			if ( 0 === strpos( $file, '#' ) || empty( $file ) ) {


### PR DESCRIPTION
Continue execution where there is no `.distignore` present.
Warn users all files will be included.

> No .distignore file found. All files in directory included in archive.

My general use has been a plugin wholly contained in a project sub-directory (#42, #45) so has no need for a .distignore.