### PR TITLE
Fix #30 : Using relative paths with and without specified filenames

### DIFF
--- a/features/dist-archive.feature
+++ b/features/dist-archive.feature
@@ -52,7 +52,7 @@ Feature: Generate a distribution archive of a project
     And the wp-content/plugins/hello-world/.travis.yml file should not exist
     And the wp-content/plugins/hello-world/bin directory should not exist
 
-  Scenario: Generate a ZIP archive to a custom path
+  Scenario: Generate a ZIP archive with a custom name
     Given a WP install
 
     When I run `wp scaffold plugin hello-world`
@@ -66,8 +66,62 @@ Feature: Generate a distribution archive of a project
       """
       Success: Created hello-world.zip
       """
-    And the hello-world.zip file should exist
+    And the wp-content/plugins/hello-world.zip file should exist
     And the wp-content/plugins/hello-world.0.1.0.zip file should not exist
+
+  Scenario: Generate a ZIP archive to a relative path without specifying the filename
+    Given a WP install
+
+    When I run `wp scaffold plugin hello-world`
+    Then the wp-content/plugins/hello-world directory should exist
+    And the wp-content/plugins/hello-world/hello-world.php file should exist
+    And the wp-content/plugins/hello-world/.travis.yml file should exist
+    And the wp-content/plugins/hello-world/bin directory should exist
+
+    When I run `wp dist-archive wp-content/plugins/hello-world wp-content`
+    Then STDOUT should be:
+      """
+      Success: Created hello-world.0.1.0.zip
+      """
+    And the wp-content/hello-world.0.1.0.zip file should exist
+    And the wp-content/plugins/hello-world.0.1.0.zip file should not exist
+
+  Scenario: Generate a ZIP archive to a relative path with a specified filename
+    Given a WP install
+
+    When I run `wp scaffold plugin hello-world`
+    Then the wp-content/plugins/hello-world directory should exist
+    And the wp-content/plugins/hello-world/hello-world.php file should exist
+    And the wp-content/plugins/hello-world/.travis.yml file should exist
+    And the wp-content/plugins/hello-world/bin directory should exist
+
+    When I run `mkdir subdir`
+    Then the subdir directory should exist
+
+    When I run `wp dist-archive wp-content/plugins/hello-world ./subdir/hello-world.zip`
+    Then STDOUT should be:
+        """
+        Success: Created hello-world.zip
+        """
+    And STDERR should be empty
+    And the {RUN_DIR}/subdir/hello-world.zip file should exist
+
+  Scenario: Generate a ZIP archive to an absolute path without specifying the filename
+    Given a WP install
+
+    When I run `wp scaffold plugin hello-world`
+    Then the wp-content/plugins/hello-world directory should exist
+    And the wp-content/plugins/hello-world/hello-world.php file should exist
+    And the wp-content/plugins/hello-world/.travis.yml file should exist
+    And the wp-content/plugins/hello-world/bin directory should exist
+
+    When I run `wp dist-archive wp-content/plugins/hello-world {RUN_DIR}/wp-content/`
+    Then STDOUT should be:
+        """
+        Success: Created hello-world.0.1.0.zip
+        """
+    And STDERR should be empty
+    And the {RUN_DIR}/wp-content/hello-world.0.1.0.zip file should exist
 
   Scenario: Generate a ZIP archive using version number in composer.json
     Given an empty directory
@@ -171,6 +225,74 @@ Feature: Generate a distribution archive of a project
       """
     And STDERR should be empty
     And the {RUN_DIR}/some/nested/folder/hello-world.zip file should exist
+
+  Scenario: Allow specifying the current directory for input using dot
+    Given a WP install
+
+    When I run `wp scaffold plugin hello-world`
+    Then the wp-content/plugins/hello-world directory should exist
+    And the wp-content/plugins/hello-world/hello-world.php file should exist
+    And the wp-content/plugins/hello-world/.travis.yml file should exist
+    And the wp-content/plugins/hello-world/bin directory should exist
+
+    When I run `wp dist-archive . {RUN_DIR}/hello-world.zip` from 'wp-content/plugins/hello-world'
+    Then STDOUT should be:
+        """
+        Success: Created hello-world.zip
+        """
+    And STDERR should be empty
+    And the {RUN_DIR}/hello-world.zip file should exist
+
+  Scenario: Use plugin parent directory for output unless otherwise specified
+    Given a WP install
+
+    When I run `wp scaffold plugin hello-world`
+    Then the wp-content/plugins/hello-world directory should exist
+    And the wp-content/plugins/hello-world/hello-world.php file should exist
+    And the wp-content/plugins/hello-world/.travis.yml file should exist
+    And the wp-content/plugins/hello-world/bin directory should exist
+
+    When I run `wp dist-archive . hello-world.zip` from 'wp-content/plugins/hello-world'
+    Then STDOUT should be:
+        """
+        Success: Created hello-world.zip
+        """
+    And STDERR should be empty
+    And the {RUN_DIR}/wp-content/plugins/hello-world.zip file should exist
+
+  Scenario: Use current directory for output when specified
+    Given a WP install
+
+    When I run `wp scaffold plugin hello-world`
+    Then the wp-content/plugins/hello-world directory should exist
+    And the wp-content/plugins/hello-world/hello-world.php file should exist
+    And the wp-content/plugins/hello-world/.travis.yml file should exist
+    And the wp-content/plugins/hello-world/bin directory should exist
+
+    When I run `wp dist-archive . ./hello-world.zip` from 'wp-content/plugins/hello-world'
+    Then STDOUT should be:
+        """
+        Success: Created hello-world.zip
+        """
+    And STDERR should be empty
+    And the {RUN_DIR}/wp-content/plugins/hello-world/hello-world.zip file should exist
+
+  Scenario: Allow specifying the current directory without filename for output using dot
+    Given a WP install
+
+    When I run `wp scaffold plugin hello-world`
+    Then the wp-content/plugins/hello-world directory should exist
+    And the wp-content/plugins/hello-world/hello-world.php file should exist
+    And the wp-content/plugins/hello-world/.travis.yml file should exist
+    And the wp-content/plugins/hello-world/bin directory should exist
+
+    When I run `wp dist-archive wp-content/plugins/hello-world .`
+    Then STDOUT should be:
+        """
+        Success: Created hello-world.0.1.0.zip
+        """
+    And STDERR should be empty
+    And the {RUN_DIR}/hello-world.0.1.0.zip file should exist
 
   Scenario: Generates an archive with another name using the plugin-dirname flag
     Given a WP install


### PR DESCRIPTION
This was not working as expected before:

> If only a path is provided, the file name defaults to the project directory name plus the version, if discoverable.

i.e. the output path wasn't correct, as discussed in #30. e.g. "`wp dist-archive . ./scratch/build.zip --create-target-dir` succeeds but the file is not placed in the subdirectory of `.`, rather it's at `../scratch/build.zip`"

Without a specified path or filename, the default output folder is the plugin's parent directory with the generated (versioned) filename.
Without a specified path, the default output folder is the plugin's parent directory with the specified filename.
With a specified path and filename, the archive is saved to that path and filename.
With a specified path and no filename, the archive is saved to that path with the generated (versioned) filename.

Tests added for:
* `wp dist-archive . hello-world.zip` – output filename, no path 
* `wp dist-archive . ./hello-world.zip` – output filename, with `.` for path
* `wp dist-archive wp-content/plugins/hello-world wp-content` – relative output path, no filename
* `wp dist-archive wp-content/plugins/hello-world ./subdir/hello-world.zip` – relative output path, with filename
* `wp dist-archive . {RUN_DIR}/hello-world.zip` – using `.` as input and absolute output path, with filename
* `wp dist-archive wp-content/plugins/hello-world .` – using `.` as output path, no filename

No documentation changed. 