### PR TITLE
Tests for 47. Allow for leading slashes in .distignore

### DIFF
--- a/.github/workflows/regenerate-readme.yml
+++ b/.github/workflows/regenerate-readme.yml
@@ -96,7 +96,7 @@ jobs:
         uses: repo-sync/pull-request@v2
         with:
           source_branch: regenerate-readme
-          destination_branch: main
+          destination_branch: ${{ github.event.repository.default_branch }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
           pr_title: Regenerate README file
           pr_body: "**This is an automated pull-request**\n\nRefreshes the `README.md` file with the latest changes to the docblocks in the source code."

--- a/features/dist-archive.feature
+++ b/features/dist-archive.feature
@@ -149,6 +149,63 @@ Feature: Generate a distribution archive of a project
       | zip     | zip       | unzip     |
       | targz   | tar.gz    | tar -zxvf |
 
+  Scenario Outline: Ignores files specified with absolute path and not similarly named files
+    Given an empty directory
+    And a foo/.distignore file:
+      """
+      /maybe-ignore-me.txt
+      """
+    And a foo/test.php file:
+      """
+      <?php
+      echo 'Hello world;';
+      """
+    And a foo/test-dir/test.php file:
+      """
+      <?php
+      echo 'Hello world;';
+      """
+    And a foo/maybe-ignore-me.txt file:
+      """
+      Ignore
+      """
+    And a foo/test-dir/maybe-ignore-me.txt file:
+      """
+      Do not ignore
+      """
+    And a foo/test-dir/foo/maybe-ignore-me.txt file:
+      """
+      Do not ignore
+      """
+
+    When I run `wp dist-archive foo --format=<format> --plugin-dirname=<plugin-dirname>`
+    Then STDOUT should be:
+      """
+      Success: Created <plugin-dirname>.<extension>
+      """
+    And the <plugin-dirname>.<extension> file should exist
+
+    When I run `rm -rf foo`
+    Then the foo directory should not exist
+
+    When I run `rm -rf <plugin-dirname>`
+    Then the <plugin-dirname> directory should not exist
+
+    When I try `<extract> <plugin-dirname>.<extension>`
+    Then the <plugin-dirname> directory should exist
+    And the <plugin-dirname>/test.php file should exist
+    And the <plugin-dirname>/test-dir/test.php file should exist
+    And the <plugin-dirname>/maybe-ignore-me.txt file should not exist
+    And the <plugin-dirname>/test-dir/maybe-ignore-me.txt file should exist
+    And the <plugin-dirname>/test-dir/foo/maybe-ignore-me.txt file should exist
+
+    Examples:
+      | format  | extension | extract   | plugin-dirname |
+      | zip     | zip       | unzip     | foo            |
+      | targz   | tar.gz    | tar -zxvf | foo            |
+      | zip     | zip       | unzip     | bar            |
+      | targz   | tar.gz    | tar -zxvf | bar            |
+
   Scenario: Create directories automatically if requested
     Given a WP install
 

--- a/features/dist-archive.feature
+++ b/features/dist-archive.feature
@@ -258,7 +258,7 @@ Feature: Generate a distribution archive of a project
       | zip     | zip       | unzip     | foo            |
       | targz   | tar.gz    | tar -zxvf | foo            |
       | zip     | zip       | unzip     | bar            |
-      | targz   | tar.gz    | tar -zxvf | bar            |
+      | targz   | tar.gz    | tar -zxvf | bar2           |
 
   Scenario: Create directories automatically if requested
     Given a WP install
@@ -408,7 +408,7 @@ Feature: Generate a distribution archive of a project
 
   Scenario: Warns but continues when no distignore file is present
     Given an empty directory
-    And a test-plugin.php file:
+    And a test-plugin/test-plugin.php file:
       """
       <?php
       /**
@@ -417,9 +417,9 @@ Feature: Generate a distribution archive of a project
        */
       """
 
-    When I try `wp dist-archive . test-plugin.zip`
+    When I try `wp dist-archive test-plugin`
     Then STDERR should contain:
       """
       No .distignore file found. All files in directory included in archive.
       """
-    And the test-plugin.zip file should exist
+    And the test-plugin.1.0.0.zip file should exist

--- a/src/Dist_Archive_Command.php
+++ b/src/Dist_Archive_Command.php
@@ -196,7 +196,7 @@ class Dist_Archive_Command {
 		}
 
 		WP_CLI::debug( "Running: {$cmd}", 'dist-archive' );
-		$ret = WP_CLI::launch( escapeshellcmd( $cmd ), false, true );
+		$ret = WP_CLI::launch( $this->escapeshellcmd( $cmd, array( '^' ) ), false, true );
 		if ( 0 === $ret->return_code ) {
 			$filename = pathinfo( $archive_file, PATHINFO_BASENAME );
 			WP_CLI::success( "Created {$filename}" );
@@ -293,5 +293,28 @@ class Dist_Archive_Command {
 			$tags[ $tag_name ] = $metadata;
 		}
 		return $tags;
+	}
+
+	/**
+	 * Run PHP's escapeshellcmd() then undo escaping known intentional characters.
+	 *
+	 * Escaped by default: &#;`|*?~<>^()[]{}$\, \x0A and \xFF. ' and " are escaped when not paired.
+	 *
+	 * @see escapeshellcmd()
+	 *
+	 * @param string $cmd The shell command to escape.
+	 * @param string[] $whitelist Array of exceptions to allow in the escaped command.
+	 *
+	 * @return string
+	 */
+	protected function escapeshellcmd( $cmd, $whitelist ) {
+
+		$escaped_command = escapeshellcmd( $cmd );
+
+		foreach ( $whitelist as $undo_escape ) {
+			$escaped_command = str_replace( '\\' . $undo_escape, $undo_escape, $escaped_command );
+		}
+
+		return $escaped_command;
 	}
 }


### PR DESCRIPTION
Example project:

```
test.php
maybe-ignore-me.txt
test-dir/maybe-ignore-me.txt
test-dir/foo/maybe-ignore-me.txt
```

with example `.distignore`:

```
/maybe-ignore-me.txt
```

Should archive:

```
test.php
test-dir/maybe-ignore-me.txt
test-dir/foo/maybe-ignore-me.txt
```

This is working for `zip`.

The tests are failing for `tar`, but when I echo the tar command that is being used and manually cd to the directory and paste and run it, it works.

Could someone please take a look and see if they can make sense of why it's not working? I'm guessing it's related to the current working directory being somehow affected inside `WP_CLI::launch()`.

@markjaquith 