### PR TITLE
Get all tests running on MacOS

### DIFF
--- a/features/dist-archive.feature
+++ b/features/dist-archive.feature
@@ -46,7 +46,7 @@ Feature: Generate a distribution archive of a project
     When I run `wp plugin delete hello-world`
     Then the wp-content/plugins/hello-world directory should not exist
 
-    When I run `cd wp-content/plugins/ && tar -zxvf hello-world.0.1.0.tar.gz`
+    When I try `cd wp-content/plugins/ && tar -zxvf hello-world.0.1.0.tar.gz`
     Then the wp-content/plugins/hello-world directory should exist
     And the wp-content/plugins/hello-world/hello-world.php file should exist
     And the wp-content/plugins/hello-world/.travis.yml file should not exist
@@ -138,7 +138,7 @@ Feature: Generate a distribution archive of a project
     When I run `rm -rf foo`
     Then the foo directory should not exist
 
-    When I run `<extract> foo.<extension>`
+    When I try `<extract> foo.<extension>`
     Then the foo directory should exist
     And the foo/test.php file should exist
     And the foo/test-dir/test.php file should exist

--- a/features/dist-archive.feature
+++ b/features/dist-archive.feature
@@ -205,7 +205,7 @@ Feature: Generate a distribution archive of a project
     And the wp-content/plugins/hello-world/.travis.yml file should exist
     And the wp-content/plugins/hello-world/bin directory should exist
 
-    When I run `sed -i wp-content/plugins/hello-world/hello-world.php -e "s/* Version/Version/" -e "s/0.1.0/0.2.0/"`
+	When I run `[[ $OSTYPE == 'darwin'* ]] && sed -i '' -e "s/* Version/Version/" -e "s/0.1.0/0.2.0/" wp-content/plugins/hello-world/hello-world.php || sed -i wp-content/plugins/hello-world/hello-world.php -e "s/* Version/Version/" -e "s/0.1.0/0.2.0/"`
     Then STDERR should be empty
 
     When I run `wp dist-archive wp-content/plugins/hello-world`


### PR DESCRIPTION
The `sed` syntax is different on MacOS than Ubuntu (i.e. the GitHub Actions runner) so running the tests fail for me during development. I have made the bash command conditional – check for Darwin and run the appropriate command.

`tar` is returning a bad exit code causing the `run` statements to fail. I've changed these to `try` and the subsequent assertions in the tests should mean ignoring the exit code at that point is acceptable. This might make PR #58 pass too.