### PR TITLE
Only parse `--plugin-dirname` parameter once. Fix #63

### DIFF
--- a/src/Dist_Archive_Command.php
+++ b/src/Dist_Archive_Command.php
@@ -161,10 +161,8 @@ class Dist_Archive_Command {
 		}
 
 		if ( $archive_base !== $source_base || $this->is_path_contains_symlink( $path ) ) {
-			$plugin_dirname = rtrim( $assoc_args['plugin-dirname'], '/' );
-			$archive_base   = $plugin_dirname;
-			$tmp_dir        = sys_get_temp_dir() . DIRECTORY_SEPARATOR . $plugin_dirname . $version . '.' . time();
-			$new_path       = $tmp_dir . DIRECTORY_SEPARATOR . $plugin_dirname;
+			$tmp_dir        = sys_get_temp_dir() . DIRECTORY_SEPARATOR . $archive_base . $version . '.' . time();
+			$new_path       = $tmp_dir . DIRECTORY_SEPARATOR . $archive_base;
 			mkdir( $new_path, 0777, true );
 			$iterator = new RecursiveIteratorIterator(
 				new RecursiveDirectoryIterator( $path, RecursiveDirectoryIterator::SKIP_DOTS ),

--- a/src/Dist_Archive_Command.php
+++ b/src/Dist_Archive_Command.php
@@ -161,8 +161,8 @@ class Dist_Archive_Command {
 		}
 
 		if ( $archive_base !== $source_base || $this->is_path_contains_symlink( $path ) ) {
-			$tmp_dir        = sys_get_temp_dir() . DIRECTORY_SEPARATOR . $archive_base . $version . '.' . time();
-			$new_path       = $tmp_dir . DIRECTORY_SEPARATOR . $archive_base;
+			$tmp_dir  = sys_get_temp_dir() . DIRECTORY_SEPARATOR . $archive_base . $version . '.' . time();
+			$new_path = $tmp_dir . DIRECTORY_SEPARATOR . $archive_base;
 			mkdir( $new_path, 0777, true );
 			$iterator = new RecursiveIteratorIterator(
 				new RecursiveDirectoryIterator( $path, RecursiveDirectoryIterator::SKIP_DOTS ),


### PR DESCRIPTION
`$archive_base` is already determined at line 105, so it is unnecessary to parse `$assoc_args['plugin-dirname']` a second time at this point.

Fix #63 