### PR TITLE
Add theme version to generated archive

### DIFF
--- a/features/dist-archive.feature
+++ b/features/dist-archive.feature
@@ -507,3 +507,23 @@ Scenario: Avoids recursive symlink
       No .distignore file found. All files in directory included in archive.
       """
     And the test-plugin.1.0.0.zip file should exist
+
+  Scenario: Generates a ZIP archive for a theme with the version appended
+	Given a WP install
+
+	When I run `wp scaffold _s new-theme`
+	Then the wp-content/themes/new-theme directory should exist
+
+	# A newly scaffold theme triggers a warning for missing .distignore
+	When I try `wp dist-archive wp-content/themes/new-theme`
+	Then STDOUT should contain:
+      """
+      Success: Created new-theme.1.0.0.zip
+      """
+	And the wp-content/themes/new-theme.1.0.0.zip file should exist
+
+	When I run `wp theme delete new-theme`
+	Then the wp-content/themes/new-theme directory should not exist
+
+	When I run `wp theme install wp-content/themes/new-theme.1.0.0.zip`
+	Then the wp-content/themes/new-theme directory should exist

--- a/src/Dist_Archive_Command.php
+++ b/src/Dist_Archive_Command.php
@@ -144,21 +144,21 @@ class Dist_Archive_Command {
 		 *
 		 * @link https://developer.wordpress.org/reference/functions/get_file_data/
 		 */
-		if( file_exists( $path . '/style.css' ) ) {
-			$contents = file_get_contents($path . '/style.css', false, null, 0, 5000);
+		if ( file_exists( $path . '/style.css' ) ) {
+			$contents = file_get_contents( $path . '/style.css', false, null, 0, 5000 );
 			$contents = str_replace( "\r", "\n", $contents );
-			$pattern = '/^' . preg_quote('Version', ',')  . ':(.*)$/mi';
-			if( preg_match( $pattern, $contents, $match ) && $match[1] ) {
+			$pattern  = '/^' . preg_quote( 'Version', ',' ) . ':(.*)$/mi';
+			if ( preg_match( $pattern, $contents, $match ) && $match[1] ) {
 				$version = '.' . trim( preg_replace( '/\s*(?:\*\/|\?>).*/', '', $match[1] ) );
 			}
 		}
 
-		if( empty( $version ) ) {
-			foreach (glob($path . '/*.php') as $php_file) {
-				$contents = file_get_contents($php_file, false, null, 0, 5000);
-				$version = $this->get_version_in_code($contents);
-				if (!empty($version)) {
-					$version = '.' . trim($version);
+		if ( empty( $version ) ) {
+			foreach ( glob( $path . '/*.php' ) as $php_file ) {
+				$contents = file_get_contents( $php_file, false, null, 0, 5000 );
+				$version  = $this->get_version_in_code( $contents );
+				if ( ! empty( $version ) ) {
+					$version = '.' . trim( $version );
 					break;
 				}
 			}

--- a/src/Dist_Archive_Command.php
+++ b/src/Dist_Archive_Command.php
@@ -136,6 +136,14 @@ class Dist_Archive_Command {
 		}
 
 		$version = '';
+
+		/**
+		 * If the path is a theme (meaning it contains a style.css file)
+		 * parse the theme's version from the headers using a regex pattern.
+		 * The pattern used is extracted from the get_file_data() function in core.
+		 *
+		 * @link https://developer.wordpress.org/reference/functions/get_file_data/
+		 */
 		if( file_exists( $path . '/style.css' ) ) {
 			$contents = file_get_contents($path . '/style.css', false, null, 0, 5000);
 			$contents = str_replace( "\r", "\n", $contents );

--- a/src/Dist_Archive_Command.php
+++ b/src/Dist_Archive_Command.php
@@ -136,12 +136,23 @@ class Dist_Archive_Command {
 		}
 
 		$version = '';
-		foreach ( glob( $path . '/*.php' ) as $php_file ) {
-			$contents = file_get_contents( $php_file, false, null, 0, 5000 );
-			$version  = $this->get_version_in_code( $contents );
-			if ( ! empty( $version ) ) {
-				$version = '.' . trim( $version );
-				break;
+		if( file_exists( $path . '/style.css' ) ) {
+			$contents = file_get_contents($path . '/style.css', false, null, 0, 5000);
+			$contents = str_replace( "\r", "\n", $contents );
+			$pattern = '/^' . preg_quote('Version', ',')  . ':(.*)$/mi';
+			if( preg_match( $pattern, $contents, $match ) && $match[1] ) {
+				$version = '.' . trim( preg_replace( '/\s*(?:\*\/|\?>).*/', '', $match[1] ) );
+			}
+		}
+
+		if( empty( $version ) ) {
+			foreach (glob($path . '/*.php') as $php_file) {
+				$contents = file_get_contents($php_file, false, null, 0, 5000);
+				$version = $this->get_version_in_code($contents);
+				if (!empty($version)) {
+					$version = '.' . trim($version);
+					break;
+				}
 			}
 		}
 


### PR DESCRIPTION
Fixes #50 by parsing the theme's version from the headers via regex.

The pattern used is extracted from the [get_file_data()](https://developer.wordpress.org/reference/functions/get_file_data/) function in core.