### PR TITLE
Ignores .git folder Fix #67

### DIFF
--- a/features/dist-archive.feature
+++ b/features/dist-archive.feature
@@ -246,6 +246,53 @@ Feature: Generate a distribution archive of a project
 			| zip    | zip       | unzip     |
 			| targz  | tar.gz    | tar -zxvf |
 
+	Scenario Outline: Ignores .git folder
+		Given an empty directory
+		And a foo/.distignore file:
+			"""
+			.git
+			"""
+		And a foo/.git/version.control file:
+			"""
+			history
+			"""
+		And a foo/.git/subfolder/version.control file:
+			"""
+			history
+			"""
+		And a foo/plugin.php file:
+			"""
+			<?php
+			echo 'Hello world';
+			"""
+
+		Then the foo/.git directory should exist
+
+		Then the foo/.git/subfolder/version.control file should exist
+
+		When I run `wp dist-archive foo --format=<format>`
+		Then STDOUT should be:
+			"""
+			Success: Created foo.<extension>
+			"""
+		And the foo.<extension> file should exist
+
+		When I run `rm -rf foo`
+		Then the foo directory should not exist
+
+		When I try `<extract> foo.<extension>`
+		Then the foo directory should exist
+		And the foo/plugin.php file should exist
+		And the foo/.git directory should not exist
+		And the foo/.git/subfolder directory should not exist
+		And the foo/.git/version.control file should not exist
+		And the foo/.git/subfolder/version.control file should not exist
+
+		Examples:
+			| format | extension | extract   |
+			| zip    | zip       | unzip     |
+			| targz  | tar.gz    | tar -zxvf |
+
 	Scenario Outline: Ignores files specified with absolute path and not similarly named files
 		Given an empty directory
 		And a foo/.distignore file:

--- a/src/Dist_Archive_Command.php
+++ b/src/Dist_Archive_Command.php
@@ -242,8 +242,9 @@ class Dist_Archive_Command {
 			$cmd      = 'tar ' . ( ( php_uname( 's' ) === 'Linux' ) ? '--anchored ' : '' ) . "{$excludes} -zcvf {$archive_filepath} {$archive_base}";
 		}
 
+		$escape_whitelist = 'targz' === $assoc_args['format'] ? array( '^', '*' ) : array();
 		WP_CLI::debug( "Running: {$cmd}", 'dist-archive' );
-		$escaped_shell_command = $this->escapeshellcmd( $cmd, array( '^', '*' ) );
+		$escaped_shell_command = $this->escapeshellcmd( $cmd, $escape_whitelist );
 		$ret                   = WP_CLI::launch( $escaped_shell_command, false, true );
 		if ( 0 === $ret->return_code ) {
 			$filename = pathinfo( $archive_filepath, PATHINFO_BASENAME );


### PR DESCRIPTION
Escaping the command line invocation of `tar` breaks wildcards and exclusions, `'^', '*'`, but NOT escaping those characters breaks `zip`. This PR conditionally escapes/does not escape based on the chosen output file format.