### PR TITLE
Add `filename-format` assoc arg

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Quick links: [Using](#using) | [Installing](#installing) | [Contributing](#contr
 ## Using
 
 ~~~
-wp dist-archive <path> [<target>] [--create-target-dir] [--plugin-dirname=<plugin-slug>] [--format=<format>]
+wp dist-archive <path> [<target>] [--create-target-dir] [--plugin-dirname=<plugin-slug>] [--format=<format>] [--filename-format=<filename-format>]
 ~~~
 
 For a plugin in a directory 'wp-content/plugins/hello-world', this command
@@ -37,8 +37,9 @@ script in each project.
 		Path to the project that includes a .distignore file.
 
 	[<target>]
-		Path and optional file name for the distribution archive. If only a path is provided the file name defaults to project directory name plus version, if discoverable.
-        If only a path if given it has to exists to function correctly.
+		Path and optional file name for the distribution archive.
+		If only a path is provided, the file name defaults to the project directory name plus the version, if discoverable.
+		Also, if only a path is given, the directory that it points to has to already exist for the command to function correctly.
 
 	[--create-target-dir]
 		Automatically create the target directory as needed.
@@ -54,6 +55,10 @@ script in each project.
 		  - zip
 		  - targz
 		---
+
+	[--filename-format=<filename-format>]
+		Use a custom format for archive filename. Defaults to '{name}.{version}'.
+		This is ignored if a custom filename is provided or version does not exist.
 
 ## Installing
 

--- a/features/dist-archive.feature
+++ b/features/dist-archive.feature
@@ -617,3 +617,58 @@ Feature: Generate a distribution archive of a project
 
 		When I run `wp theme install wp-content/themes/new-theme.1.0.0.zip`
 		Then the wp-content/themes/new-theme directory should exist
+
+	Scenario: Generates a ZIP archive with a custom filename format
+		Given a WP install
+
+		When I run `wp scaffold plugin hello-world`
+		Then the wp-content/plugins/hello-world directory should exist
+		And the wp-content/plugins/hello-world/hello-world.php file should exist
+		And the wp-content/plugins/hello-world/.travis.yml file should exist
+		And the wp-content/plugins/hello-world/bin directory should exist
+
+		When I run `wp dist-archive wp-content/plugins/hello-world --filename-format={name}-{version}`
+		Then STDOUT should be:
+			"""
+			Success: Created hello-world-0.1.0.zip
+			"""
+		And STDERR should be empty
+		And the wp-content/plugins/hello-world-0.1.0.zip file should exist
+
+	Scenario: Ignores filename format when custom name is provided
+		Given a WP install
+
+		When I run `wp scaffold plugin hello-world`
+		Then the wp-content/plugins/hello-world directory should exist
+		And the wp-content/plugins/hello-world/hello-world.php file should exist
+		And the wp-content/plugins/hello-world/.travis.yml file should exist
+		And the wp-content/plugins/hello-world/bin directory should exist
+
+		When I run `wp dist-archive wp-content/plugins/hello-world hello-world.zip --filename-format={name}-{version}`
+		Then STDOUT should be:
+			"""
+			Success: Created hello-world.zip
+			"""
+		And STDERR should be empty
+		And the wp-content/plugins/hello-world.zip file should exist
+		And the wp-content/plugins/hello-world-0.1.0.zip file should not exist
+
+	Scenario: Ignores filename format when version does not exist
+		Given an empty directory
+		And a foo/.distignore file:
+			"""
+			/maybe-ignore-me.txt
+			"""
+		And a foo/test.php file:
+			"""
+			<?php
+			echo 'Hello world;';
+			"""
+
+		When I run `wp dist-archive foo --filename-format={name}-{version}`
+		Then STDOUT should be:
+			"""
+			Success: Created foo.zip
+			"""
+		And STDERR should be empty
+		And the foo.zip file should exist


### PR DESCRIPTION
Fixes: #72 

This PR addresses the following -

- Add `filename-format` assoc arg to customize the name of the archive file name
- By default, it is in the format `{name}.{version}`. Examples - `{name}-{version}` , `{name}-myOrg.{version}-dist`
- This parameter will be ignored if 
   - a custom filename is provided
   - version does not exist
- Add feature test cases

Screenshots

![image](https://github.com/wp-cli/dist-archive-command/assets/60139930/469b56cf-b982-4be0-9422-3506e1e7add8)
