### PR TITLE
Do not match partially matching file names

### DIFF
--- a/src/Dist_Archive_Command.php
+++ b/src/Dist_Archive_Command.php
@@ -430,7 +430,7 @@ class Dist_Archive_Command {
 			// We don't want to quote `*` in regex pattern, later we'll replace it with `.*`.
 			$pattern = str_replace( '*', '&ast;', $entry );
 
-			$pattern = '/' . preg_quote( $pattern, '/' ) . '/';
+			$pattern = '/' . preg_quote( $pattern, '/' ) . '$/';
 
 			$pattern = str_replace( '&ast;', '.*', $pattern );
 


### PR DESCRIPTION
Resolves the issue reported at https://github.com/wp-cli/dist-archive-command/issues/44#issuecomment-1677135516 where ignoring `foo.js` would exclude `foo.json` without the ability to force-include the latter.