### PR TITLE
Restrict PHP versions used in GitHub Actions

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -12,3 +12,6 @@ on:
 jobs:
   test:
     uses: wp-cli/.github/.github/workflows/reusable-testing.yml@main
+    with:
+      matrix-php-versions-unit: "['7.1', '7.2', '7.3', '7.4', '8.0', '8.1', '8.2', '8.3']"
+      matrix-php-versions-functional: "['7.1', '7.2', '7.3', '7.4', '8.0', '8.1', '8.2', '8.3']"


### PR DESCRIPTION

See full description at: https://github.com/wp-cli/.github/pull/74