### PR TITLE
Dist Archive: ask user confirmation if file exists before overwriting it

### DIFF
--- a/features/dist-archive.feature
+++ b/features/dist-archive.feature
@@ -437,3 +437,32 @@ Feature: Generate a distribution archive of a project
       """
     And STDERR should be empty
     And the foo.zip file should exist
+
+  Scenario: Ask for confirmation if archive file exists
+    Given a WP install
+
+    When I run `wp scaffold plugin hello-world`
+    Then the wp-content/plugins/hello-world directory should exist
+    And the wp-content/plugins/hello-world/hello-world.php file should exist
+    And the wp-content/plugins/hello-world/.travis.yml file should exist
+    And the wp-content/plugins/hello-world/bin directory should exist
+
+    When I run `mkdir subdir`
+    Then the subdir directory should exist
+
+    When I run `wp dist-archive wp-content/plugins/hello-world ./subdir/hello-world-dist.zip`
+    Then STDOUT should be:
+      """
+      Success: Created hello-world-dist.zip
+      """
+    And STDERR should be empty
+    And the {RUN_DIR}/subdir/hello-world-dist.zip file should exist
+
+    When I run `wp dist-archive wp-content/plugins/hello-world ./subdir/hello-world-dist.zip --yes`
+    Then STDOUT should contain:
+      """
+      Warning: The file '{RUN_DIR}/subdir/hello-world-dist.zip' already exists.
+      Success: Created hello-world-dist.zip
+      """
+    And STDERR should be empty
+    And the {RUN_DIR}/subdir/hello-world-dist.zip file should exist

--- a/src/Dist_Archive_Command.php
+++ b/src/Dist_Archive_Command.php
@@ -263,7 +263,7 @@ class Dist_Archive_Command {
 
 
 		$escape_whitelist = 'targz' === $assoc_args['format'] ? array( '^', '*' ) : array();
-		WP_CLI::debug( "yay Running: {$cmd}", 'dist-archive' );
+		WP_CLI::debug( "Running: {$cmd}", 'dist-archive' );
 		$escaped_shell_command = $this->escapeshellcmd( $cmd, $escape_whitelist );
 		$ret                   = WP_CLI::launch( $escaped_shell_command, false, true );
 		if ( 0 === $ret->return_code ) {

--- a/src/Dist_Archive_Command.php
+++ b/src/Dist_Archive_Command.php
@@ -46,6 +46,9 @@ class Dist_Archive_Command {
 	 * [--create-target-dir]
 	 * : Automatically create the target directory as needed.
 	 *
+	 * [--yes]
+	 * : Answer yes to confirm overwriting the archive file if it already exists.
+	 *
 	 * [--plugin-dirname=<plugin-slug>]
 	 * : Set the archive extract directory name. Defaults to project directory name.
 	 *
@@ -195,6 +198,11 @@ class Dist_Archive_Command {
 		}
 		$archive_absolute_filepath = "{$archive_path}/{$archive_filename}";
 
+		if ( file_exists( $archive_absolute_filepath ) ) {
+			WP_CLI::warning( "The file '{$archive_absolute_filepath}' already exists." );
+			WP_CLI::confirm( 'Do you want to overwrite it?', $assoc_args );
+		}
+
 		chdir( dirname( $source_path ) );
 
 		if ( Utils\get_flag_value( $assoc_args, 'create-target-dir' ) ) {
@@ -253,8 +261,9 @@ class Dist_Archive_Command {
 			}
 		}
 
+
 		$escape_whitelist = 'targz' === $assoc_args['format'] ? array( '^', '*' ) : array();
-		WP_CLI::debug( "Running: {$cmd}", 'dist-archive' );
+		WP_CLI::debug( "yay Running: {$cmd}", 'dist-archive' );
 		$escaped_shell_command = $this->escapeshellcmd( $cmd, $escape_whitelist );
 		$ret                   = WP_CLI::launch( $escaped_shell_command, false, true );
 		if ( 0 === $ret->return_code ) {

--- a/src/Dist_Archive_Command.php
+++ b/src/Dist_Archive_Command.php
@@ -261,7 +261,6 @@ class Dist_Archive_Command {
 			}
 		}
 
-
 		$escape_whitelist = 'targz' === $assoc_args['format'] ? array( '^', '*' ) : array();
 		WP_CLI::debug( "Running: {$cmd}", 'dist-archive' );
 		$escaped_shell_command = $this->escapeshellcmd( $cmd, $escape_whitelist );


### PR DESCRIPTION
- Related to:
  - https://github.com/wp-cli/wp-cli/issues/5859
  - https://github.com/wp-cli/dist-archive-command/issues/70

## Description

I'm checking if `archive_absolute_filepath` exists, then we display a warning and ask for confirmation to overwrite.
I also added a new argument `--yes` to auto confirm and overwrite anyway. In this case we still showing the warning.

## Testing instructions

I wrote a new test scenario but I cannot make it run. I got the error:
```
The process "run-behat-tests 'features/dist-archive.feature:441'" exceeded the timeout of 300 seconds.
```

This error I  get it even without my changes. So my test probably is not correct yet.

Given a "pluginPath":
1. Run `vendor/bin/wp dist-archive pluginPath`
2. Observe it display a success message: `Success: Created ...zip`
3. Run the same command `vendor/bin/wp dist-archive pluginPath`
4. Observe the cli displays a warning and asks for confirmation
5. type `n`
6. Observe the cli exists without continuing the process
7. Run the same command `vendor/bin/wp dist-archive pluginPath`
8. type `y`
9. Observe it display a success message: `Success: Created ...zip`
10. Run the same command appending `--yes`: `vendor/bin/wp dist-archive pluginPath --yes`
11.Observe it display a warning and a success message: `Success: Created ...zip` without asking for confirmation.


## Screencast


https://github.com/wp-cli/dist-archive-command/assets/779993/bf188f53-03d6-415f-8670-f3ded19a4aa2

