### PR TITLE
Bump minimum supported version to PHP 7.4

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -13,4 +13,4 @@ jobs:
   test:
     uses: wp-cli/.github/.github/workflows/reusable-testing.yml@main
     with:
-      minimum-php: '7.1'
+      minimum-php: '7.4'

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
         }
     ],
     "require": {
-        "php": ">=7.1",
+        "php": ">=7.4",
         "wp-cli/wp-cli": "^2",
         "inmarelibero/gitignore-checker": "^1.0.2"
     },


### PR DESCRIPTION
PHP 7.1 [started failing randomly](https://github.com/wp-cli/dist-archive-command/actions/runs/7119158164/job/19383844313?pr=85). I don't think it's worth the effort to try and fix it.