### PR TITLE
Update `inmarelibero/gitignore-checker` to fix deprecation warning

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
     "require": {
         "php": ">=7.4",
         "wp-cli/wp-cli": "^2",
-        "inmarelibero/gitignore-checker": "^1.0.2"
+        "inmarelibero/gitignore-checker": "^1.0.4"
     },
     "require-dev": {
         "wp-cli/wp-cli-tests": "^4",


### PR DESCRIPTION
Increase the version of `inmarelibero/gitignore-checker` to the latest, which does not result in deprecation warnings when running under PHP 8.2+.

See: 
* https://github.com/inmarelibero/gitignore-checker/pull/14
* https://github.com/inmarelibero/gitignore-checker/tags
* https://packagist.org/packages/inmarelibero/gitignore-checker

Fix #95 