### PR TITLE
Add --force option to overwrite

### DIFF
--- a/features/dist-archive.feature
+++ b/features/dist-archive.feature
@@ -494,3 +494,15 @@ Feature: Generate a distribution archive of a project
       """
     And the {RUN_DIR}/subdir/hello-world-dist.zip file should exist
     And the return code should be 0
+
+    When I try `wp dist-archive wp-content/plugins/hello-world ./subdir/hello-world-dist.zip --force`
+    And STDERR should contain:
+      """
+      Warning: Archive file already exists
+      """
+    And STDOUT should contain:
+      """
+      Success: Created hello-world-dist.zip
+      """
+    And the {RUN_DIR}/subdir/hello-world-dist.zip file should exist
+    And the return code should be 0

--- a/features/dist-archive.feature
+++ b/features/dist-archive.feature
@@ -495,14 +495,18 @@ Feature: Generate a distribution archive of a project
     And the {RUN_DIR}/subdir/hello-world-dist.zip file should exist
     And the return code should be 0
 
-    When I try `wp dist-archive wp-content/plugins/hello-world ./subdir/hello-world-dist.zip --force`
-    And STDERR should contain:
-      """
-      Warning: Archive file already exists
-      """
+  Scenario: Do not ask for confirmation if archive file exists when using --force
+    Given a WP install
+
+    When I run `wp scaffold plugin hello-world`
+    Then the wp-content/plugins/hello-world directory should exist
+
+    When I run `wp dist-archive wp-content/plugins/hello-world ./hello-world-dist.zip`
+    Then STDERR should be empty
+
+    When I try `wp dist-archive wp-content/plugins/hello-world ./hello-world-dist.zip --force`
+    Then STDERR should be empty
     And STDOUT should contain:
       """
       Success: Created hello-world-dist.zip
       """
-    And the {RUN_DIR}/subdir/hello-world-dist.zip file should exist
-    And the return code should be 0

--- a/src/Dist_Archive_Command.php
+++ b/src/Dist_Archive_Command.php
@@ -46,6 +46,9 @@ class Dist_Archive_Command {
 	 * [--create-target-dir]
 	 * : Automatically create the target directory as needed.
 	 *
+	 * [--force]
+	 * : Forces overwriting of the archive file if it already exists.
+	 *
 	 * [--plugin-dirname=<plugin-slug>]
 	 * : Set the archive extract directory name. Defaults to project directory name.
 	 *
@@ -102,12 +105,15 @@ class Dist_Archive_Command {
 		if ( file_exists( $archive_absolute_filepath ) ) {
 			WP_CLI::warning( 'Archive file already exists' );
 			WP_CLI::log( $archive_absolute_filepath );
-			$answer      = \cli\prompt(
-				'Do you want to skip or replace it with a new archive?',
-				$default = false,
-				$marker  = ' [s/r]: '
-			);
-			$should_overwrite = 'r' === strtolower( $answer );
+			$should_overwrite = Utils\get_flag_value( $assoc_args, 'force' );
+			if ( ! $should_overwrite ) {
+				$answer      = \cli\prompt(
+					'Do you want to skip or replace it with a new archive?',
+					$default = false,
+					$marker  = ' [s/r]: '
+				);
+				$should_overwrite = 'r' === strtolower( $answer );
+			}
 			if ( ! $should_overwrite ) {
 				WP_CLI::log( 'Skipping' . PHP_EOL );
 				WP_CLI::log( 'Archive generation skipped.' );

--- a/src/Dist_Archive_Command.php
+++ b/src/Dist_Archive_Command.php
@@ -103,10 +103,10 @@ class Dist_Archive_Command {
 		$archive_absolute_filepath = "{$destination_dir_path}/{$archive_file_name}";
 
 		if ( file_exists( $archive_absolute_filepath ) ) {
-			WP_CLI::warning( 'Archive file already exists' );
-			WP_CLI::log( $archive_absolute_filepath );
 			$should_overwrite = Utils\get_flag_value( $assoc_args, 'force' );
 			if ( ! $should_overwrite ) {
+				WP_CLI::warning( 'Archive file already exists' );
+				WP_CLI::log( $archive_absolute_filepath );
 				$answer      = \cli\prompt(
 					'Do you want to skip or replace it with a new archive?',
 					$default = false,
@@ -119,7 +119,7 @@ class Dist_Archive_Command {
 				WP_CLI::log( 'Archive generation skipped.' );
 				exit( 0 );
 			}
-			WP_CLI::log( 'Replacing' . PHP_EOL );
+			WP_CLI::log( "Replacing $archive_absolute_filepath" . PHP_EOL );
 		}
 
 		chdir( dirname( $source_path ) );


### PR DESCRIPTION
Fixes #99 

Adds a `--force` option that forces overwrite of an existing file. This prevents having to answer the prompt inside a script.

`--force` was chosen to match the `wp plugin/theme install` command options.

Added a test for the new option.

Part of https://github.com/wp-cli/wp-cli/issues/5985