### PR TITLE
Do not scaffold theme in test

### DIFF
--- a/features/dist-archive.feature
+++ b/features/dist-archive.feature
@@ -324,22 +324,22 @@ Feature: Generate a distribution archive of a project
   Scenario: Generates a ZIP archive for a theme with the version appended
     Given a WP install
 
-    When I run `wp scaffold _s new-theme`
-    Then the wp-content/themes/new-theme directory should exist
+    When I run `wp theme install twentytwelve --force --version=4.7`
+    Then the wp-content/themes/twentytwelve directory should exist
 
-    # A newly scaffold theme triggers a warning for missing .distignore
-    When I try `wp dist-archive wp-content/themes/new-theme`
+    # There is a warning for a missing .distignore file.
+    When I try `wp dist-archive wp-content/themes/twentytwelve`
     Then STDOUT should contain:
       """
-      Success: Created new-theme.1.0.0.zip
+      Success: Created twentytwelve.4.7.zip
       """
-    And the wp-content/themes/new-theme.1.0.0.zip file should exist
+    And the wp-content/themes/twentytwelve.4.7.zip file should exist
 
-    When I run `wp theme delete new-theme`
-    Then the wp-content/themes/new-theme directory should not exist
+    When I run `wp theme delete twentytwelve`
+    Then the wp-content/themes/twentytwelve directory should not exist
 
-    When I run `wp theme install wp-content/themes/new-theme.1.0.0.zip`
-    Then the wp-content/themes/new-theme directory should exist
+    When I run `wp theme install wp-content/themes/twentytwelve.4.7.zip`
+    Then the wp-content/themes/twentytwelve directory should exist
 
   Scenario: Generates a ZIP archive with a custom filename format
     Given a WP install


### PR DESCRIPTION
One test used `wp scaffold _s` but http://underscores.me/ is currently down so it fails.

While the site may be up again eventually, there's no reason we need to scaffold a theme for this test, we can just use an existing one. Makes the test more stable.