### PR TITLE
Validate version format and escape tar command arguments

### DIFF
--- a/features/dist-archive.feature
+++ b/features/dist-archive.feature
@@ -562,3 +562,58 @@ Feature: Generate a distribution archive of a project
       """
       foo/foo.txt
       """
+
+  Scenario: Prevents GNU tar argument injection via Version header
+    Given an empty directory
+    And a foo/.distignore file:
+      """
+      """
+    And a foo/style.css file:
+      """
+      /*
+      Theme Name: Test Theme
+      Version: 1.0 --checkpoint=1 --checkpoint-action=exec=foo/pwn.sh --owner=x
+      */
+      """
+    And a foo/pwn.sh file:
+      """
+      echo "RCE" > rce_proof.txt
+      """
+
+    When I run `wp dist-archive foo --format=targz`
+    Then STDOUT should match /^Success: Created foo.tar.gz \(Size: \d+(?:\.\d*)? [a-zA-Z]{1,3}\)$/
+    And the foo.tar.gz file should exist
+    And the rce_proof.txt file should not exist
+
+  Scenario: Rejects invalid version headers in plugin PHP file and composer.json
+    Given an empty directory
+    And a bar/.distignore file:
+      """
+      """
+    And a bar/bar.php file:
+      """
+      <?php
+      /*
+      Plugin Name: Test Plugin
+      Version: 2.0 --checkpoint=1 --owner=x
+      */
+      """
+
+    When I run `wp dist-archive bar --format=targz`
+    Then STDOUT should match /^Success: Created bar.tar.gz \(Size: \d+(?:\.\d*)? [a-zA-Z]{1,3}\)$/
+    And the bar.tar.gz file should exist
+
+    Given a baz/.distignore file:
+      """
+      """
+    And a baz/composer.json file:
+      """
+      {
+        "name": "vendor/baz",
+        "version": "3.0 --checkpoint=1 --owner=x"
+      }
+      """
+
+    When I run `wp dist-archive baz --format=targz`
+    Then STDOUT should match /^Success: Created baz.tar.gz \(Size: \d+(?:\.\d*)? [a-zA-Z]{1,3}\)$/
+    And the baz.tar.gz file should exist

--- a/src/Dist_Archive_Command.php
+++ b/src/Dist_Archive_Command.php
@@ -142,7 +142,7 @@ class Dist_Archive_Command {
 			// If the files are being zipped in place, we need the exclusion rules.
 			// whereas if they were copied for any reasons above, the rules have already been applied.
 			if ( $source_path !== $source_dir_path || empty( $file_ignore_rules ) ) {
-				$cmd = "tar -zcvf {$archive_absolute_filepath} {$archive_output_dir_name}";
+				$cmd = Utils\esc_cmd( 'tar -zcvf %s %s', $archive_absolute_filepath, $archive_output_dir_name );
 			} else {
 				$tmp_dir = sys_get_temp_dir() . '/' . uniqid( $archive_file_name );
 				mkdir( $tmp_dir, 0777, true );
@@ -161,7 +161,7 @@ class Dist_Archive_Command {
 					trim( implode( "\n", $excludes ) )
 				);
 				$anchored_flag = ( php_uname( 's' ) === 'Linux' ) ? '--anchored ' : '';
-				$cmd           = "tar {$anchored_flag} --exclude-from={$exclude_list_filepath} -zcvf {$archive_absolute_filepath} {$archive_output_dir_name}";
+				$cmd           = Utils\esc_cmd( "tar {$anchored_flag}--exclude-from=%s -zcvf %s %s", $exclude_list_filepath, $archive_absolute_filepath, $archive_output_dir_name );
 			}
 
 			$escape_whitelist = array( '^', '*' );
@@ -286,7 +286,10 @@ class Dist_Archive_Command {
 			$contents = str_replace( "\r", "\n", $contents );
 			$pattern  = '/^' . preg_quote( 'Version', ',' ) . ':(.*)$/mi';
 			if ( preg_match( $pattern, $contents, $match ) && $match[1] ) {
-				$version = trim( (string) preg_replace( '/\s*(?:\*\/|\?>).*/', '', $match[1] ) );
+				$matched_version = trim( (string) preg_replace( '/\s*(?:\*\/|\?>).*/', '', $match[1] ) );
+				if ( preg_match( '/^[A-Za-z0-9][A-Za-z0-9._+-]*$/', $matched_version ) ) {
+					$version = $matched_version;
+				}
 			}
 		}
 
@@ -299,8 +302,11 @@ class Dist_Archive_Command {
 				$contents = str_replace( "\r", "\n", $contents );
 				$pattern  = '/^[ \t\/*#@]*Version:(.*)$/mi';
 				if ( preg_match( $pattern, $contents, $match ) && $match[1] ) {
-					$version = trim( (string) preg_replace( '/\s*(?:\*\/|\?>).*/', '', $match[1] ) );
-					break;
+					$matched_version = trim( (string) preg_replace( '/\s*(?:\*\/|\?>).*/', '', $match[1] ) );
+					if ( preg_match( '/^[A-Za-z0-9][A-Za-z0-9._+-]*$/', $matched_version ) ) {
+						$version = $matched_version;
+						break;
+					}
 				}
 			}
 		}
@@ -311,7 +317,10 @@ class Dist_Archive_Command {
 			 */
 			$composer_obj = json_decode( (string) file_get_contents( $source_dir_path . '/composer.json' ) );
 			if ( $composer_obj && ! empty( $composer_obj->version ) ) {
-				$version = trim( $composer_obj->version );
+				$matched_version = trim( (string) $composer_obj->version );
+				if ( preg_match( '/^[A-Za-z0-9][A-Za-z0-9._+-]*$/', $matched_version ) ) {
+					$version = $matched_version;
+				}
 			}
 		}
 
@@ -319,11 +328,15 @@ class Dist_Archive_Command {
 			/**
 			 * @var WP_CLI\ProcessRun $response
 			 */
-			$response   = WP_CLI::launch( "cd {$source_dir_path}; git log --pretty=format:'%h' -n 1", false, true );
+			$response   = WP_CLI::launch( Utils\esc_cmd( 'git -C %s log --pretty=format:%%h -n 1', $source_dir_path ), false, true );
 			$maybe_hash = trim( $response->stdout );
-			if ( $maybe_hash && 7 === strlen( $maybe_hash ) ) {
+			if ( $maybe_hash && 7 === strlen( $maybe_hash ) && preg_match( '/^[0-9a-f]{7}$/i', $maybe_hash ) ) {
 				$version .= '-' . $maybe_hash;
 			}
+		}
+
+		if ( ! empty( $version ) && ! preg_match( '/^[A-Za-z0-9][A-Za-z0-9._+-]*$/', $version ) ) {
+			return '';
 		}
 
 		return $version;


### PR DESCRIPTION
Applying some slight hardening to validate version strings extracted from `style.css`, PHP files, and `composer.json` to ensure they conform to valid version characters and prevent argument injection into GNU tar commands. Also use `Utils\esc_cmd` to safely quote parameters passed to tar and git log commands.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved archive creation to prevent malicious metadata from injecting commands during tarball generation.
  - Added validation for theme, plugin, and Composer version information, safely ignoring invalid values.
  - Restricted Git commit identifiers to valid seven-character hexadecimal hashes before including them in archive metadata.
- **Tests**
  - Added acceptance coverage confirming that crafted metadata cannot execute commands and that archives are still generated successfully.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->