### PR TITLE
Drop escapeshellcmd() pass on tar command line

### DIFF
--- a/features/dist-archive.feature
+++ b/features/dist-archive.feature
@@ -617,3 +617,23 @@ Feature: Generate a distribution archive of a project
     When I run `wp dist-archive baz --format=targz`
     Then STDOUT should match /^Success: Created baz.tar.gz \(Size: \d+(?:\.\d*)? [a-zA-Z]{1,3}\)$/
     And the baz.tar.gz file should exist
+
+  Scenario: Generates a tarball archive when directory path contains special characters
+    Given an empty directory
+    And a plug(1)/.distignore file:
+      """
+      """
+    And a plug(1)/plug.php file:
+      """
+      <?php
+      /*
+      Plugin Name: Plug 1
+      Version: 1.0.0
+      */
+      """
+
+    When I run `wp dist-archive 'plug(1)' --format=targz`
+    Then STDOUT should match /^Success: Created plug\(1\).1.0.0.tar.gz \(Size: \d+(?:\.\d*)? [a-zA-Z]{1,3}\)$/
+    And the plug(1).1.0.0.tar.gz file should exist
+
+

--- a/src/Dist_Archive_Command.php
+++ b/src/Dist_Archive_Command.php
@@ -164,14 +164,12 @@ class Dist_Archive_Command {
 				$cmd           = Utils\esc_cmd( "tar {$anchored_flag}--exclude-from=%s -zcvf %s %s", $exclude_list_filepath, $archive_absolute_filepath, $archive_output_dir_name );
 			}
 
-			$escape_whitelist = array( '^', '*' );
 			WP_CLI::debug( "Running: {$cmd}", 'dist-archive' );
-			$escaped_shell_command = $this->escapeshellcmd( $cmd, $escape_whitelist );
 
 			/**
 			 * @var WP_CLI\ProcessRun $ret
 			 */
-			$ret = WP_CLI::launch( $escaped_shell_command, false, true );
+			$ret = WP_CLI::launch( $cmd, false, true );
 			if ( 0 !== $ret->return_code ) {
 				$error = $ret->stderr ?: $ret->stdout;
 				WP_CLI::error( $error );
@@ -352,29 +350,6 @@ class Dist_Archive_Command {
 		if ( ! is_dir( $destination_dir_path ) ) {
 			mkdir( $destination_dir_path, $mode = 0777, $recursive = true );
 		}
-	}
-
-	/**
-	 * Run PHP's escapeshellcmd() then undo escaping known intentional characters.
-	 *
-	 * Escaped by default: &#;`|*?~<>^()[]{}$\, \x0A and \xFF. ' and " are escaped when not paired.
-	 *
-	 * @see escapeshellcmd()
-	 *
-	 * @param string $cmd The shell command to escape.
-	 * @param string[] $whitelist Array of exceptions to allow in the escaped command.
-	 *
-	 * @return string
-	 */
-	protected function escapeshellcmd( $cmd, $whitelist ) {
-
-		$escaped_command = escapeshellcmd( $cmd );
-
-		foreach ( $whitelist as $undo_escape ) {
-			$escaped_command = str_replace( '\\' . $undo_escape, $undo_escape, $escaped_command );
-		}
-
-		return $escaped_command;
 	}
 
 


### PR DESCRIPTION
Follow-up to #131.

### Overview
`Utils\esc_cmd()` safely single-quotes arguments passed to the shell. Calling `$this->escapeshellcmd()` on the output of `esc_cmd()` caused PHP's native `escapeshellcmd()` to insert backslashes before special characters (such as parentheses `(`, `)`, `$`, `;`, etc.) inside single quotes `'...'`. In shell execution, backslashes inside single quotes are interpreted as literal backslashes, causing `tar` command line invocations to fail when project directory paths contain special characters.

### Changes
- Removed the `$this->escapeshellcmd()` pass prior to launching the `tar` process and removed the unused helper method.
- Added a Behat test scenario verifying `wp dist-archive` runs cleanly on project paths containing parentheses.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed tarball generation for source directories whose names contain parentheses.
  * Archive creation now produces the expected escaped filename and successfully generates the archive.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->